### PR TITLE
Update to use PHPUnit 8 for development

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ dist: trusty
 language: php
 
 php:
-- '7.1'
+- '7.2'
+- '7.3'
 
 ## Cache composer
 cache:

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "description": "An object oriented class for the DiffChecker tool.",
     "license": "MIT",
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
         "symfony/console": "^4.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "symfony/console": "^4.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.5",
+        "phpunit/phpunit": "^8.0",
         "squizlabs/php_codesniffer": "^3.1"
     },
     "autoload": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This updates to use PHPUnit 8. [Version 6 is now deprecated and no longer supported](https://phpunit.de/getting-started/phpunit-6.html).

As PHPUnit 8 requires PHP 7.2 or greater, this also deprecates support for PHP 7.1

## Types of changes

Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

Put an `x` in all the boxes that apply:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
