### PR TITLE
Remove PHP_CodeSniffer as a dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ before_script:
 - travis_retry composer update --no-interaction --prefer-dist
 
 script:
-- vendor/bin/phpcs --standard=psr2 src/
 - vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover
 
 after_success:

--- a/composer.json
+++ b/composer.json
@@ -8,8 +8,7 @@
         "symfony/console": "^4.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.0",
-        "squizlabs/php_codesniffer": "^3.1"
+        "phpunit/phpunit": "^8.0"
     },
     "autoload": {
         "psr-4": {
@@ -22,9 +21,7 @@
         }
     },
     "scripts": {
-        "test": "phpunit",
-        "check-style": "phpcs -p --standard=PSR2 --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1 src tests",
-        "fix-style": "phpcbf -p --standard=PSR2 --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1 src tests"
+        "test": "phpunit"
     },
     "bin": [
         "bin/diffchecker"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This removes PHP_CodeSniffer as a dependency to rely on the Style CI configuration instead.

## Types of changes

Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

Put an `x` in all the boxes that apply:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
